### PR TITLE
fix events call with continuation token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ npm-debug.log
 # Ignore docker volumes
 .volumes
 
+# Ignore .env
+.env
+
 # Ignore juno files
 juno_files
 

--- a/lib/starknet_explorer/events.ex
+++ b/lib/starknet_explorer/events.ex
@@ -204,18 +204,18 @@ defmodule StarknetExplorer.Events do
       Enum.flat_map_reduce(1..1000, nil, fn _, acc ->
         if acc == "last_page_reached" do
           {:halt, acc}
-        end
+        else
+          case try_fetch_next_page(block_hash, network, acc) do
+            {:ok, %{"events" => events, "continuation_token" => continuation_token}} ->
+              {events, continuation_token}
 
-        case try_fetch_next_page(block_hash, network, acc) do
-          {:ok, %{"events" => events, "continuation_token" => continuation_token}} ->
-            {events, continuation_token}
+            # when no continuation token is present, this means that we reached the end of the events.
+            {:ok, %{"events" => events}} ->
+              {events, "last_page_reached"}
 
-          # when no continuation token is present, this means that we reached the end of the events.
-          {:ok, %{"events" => events}} ->
-            {events, "last_page_reached"}
-
-          _err ->
-            {:halt, acc}
+            _err ->
+              {:halt, acc}
+          end
         end
       end)
 


### PR DESCRIPTION
When fetching events over the RPC, the loop should halt when there’s no `continuation token` in the response. However, we noticed that another call is made to the RPC with `continuation_token` as `last_page_reached`. This call fails and after that the loop halts.

So we moved that part inside else. Not sure if this is the pragmatic way but it fixes the problem.
