### PR TITLE
add PHX_HOST in origin without port

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -118,7 +118,9 @@ if config_env() == :prod do
       "https://www.starkcompass.com",
       "https://testing.starkcompass.com",
       "https://#{host}:#{port}",
-      "http://#{host}:#{port}"
+      "http://#{host}:#{port}",
+      "http://#{host}",
+      "https://#{host}"
     ],
     http: [
       # Enable IPv6 and bind on all interfaces.


### PR DESCRIPTION
Right now, if we host the explorer on a different URL then the ones mentioned, the ws connection fails. Even if we specify the host using `PHX_HOST`, it still fails because `PHX_HOST` is suffixed with the port number. With this PR, the `PHX_HOST` will be added to check origin and we won't need to change the code for new deployments.