### PR TITLE
Support Juno 0.9.2 responses

### DIFF
--- a/lib/starknet_explorer/block/block_utils.ex
+++ b/lib/starknet_explorer/block/block_utils.ex
@@ -190,7 +190,6 @@ defmodule StarknetExplorer.BlockUtils do
     |> Enum.map(fn
       %{"execution_resources" => %{"steps" => steps}} ->
         steps
-        |> StarknetExplorerWeb.Utils.hex_to_integer()
 
       _ ->
         nil

--- a/lib/starknet_explorer/transaction.ex
+++ b/lib/starknet_explorer/transaction.ex
@@ -243,7 +243,8 @@ defmodule StarknetExplorer.Transaction do
 
   defp validate_according_to_tx_type(changeset, _tx = %{"type" => "INVOKE"}) do
     changeset
-    |> validate_required(@invoke_v0_tx_fields)
+    # Skip required fields check because of Juno0.9.2 breaking changes
+    # |> validate_required(@invoke_v0_tx_fields)
   end
 
   defp validate_according_to_tx_type(changeset, _tx = %{"type" => "DEPLOY", "max_fee" => _}) do

--- a/lib/starknet_explorer/transaction_receipt.ex
+++ b/lib/starknet_explorer/transaction_receipt.ex
@@ -93,7 +93,7 @@ defmodule StarknetExplorer.TransactionReceipt do
   schema "transaction_receipts" do
     belongs_to :transaction, Transaction, references: :hash
     field :type, :string
-    field :actual_fee, :string
+    field :actual_fee, :map
     field :finality_status, :string
     field :execution_status, :string
     field :block_hash, :string

--- a/lib/starknet_explorer_web/live/transaction_live.ex
+++ b/lib/starknet_explorer_web/live/transaction_live.ex
@@ -539,10 +539,10 @@ defmodule StarknetExplorerWeb.TransactionLive do
         </div>
         <div class="flex flex-col lg:flex-row items-center gap-5 px-5 md:p-0">
           <div class="flex flex-col justify-center items-center gap-2">
-            <span class="blue-label py-1 px-2 rounded-lg">STEPS</span> <%= "#{Utils.hex_to_integer(@transaction_receipt.execution_resources["steps"])}" %>
+            <span class="blue-label py-1 px-2 rounded-lg">STEPS</span> <%= "#{@transaction_receipt.execution_resources["steps"]}" %>
           </div>
           <div class="flex flex-col justify-center items-center gap-2">
-            <span class="green-label py-1 px-2 rounded-lg">MEMORY HOLES</span> <%= "#{Utils.hex_to_integer(@transaction_receipt.execution_resources["memory_holes"])}" %>
+            <span class="green-label py-1 px-2 rounded-lg">MEMORY HOLES</span> <%= "#{@transaction_receipt.execution_resources["memory_holes"]}" %>
           </div>
           <%= for {builtin_name, resources} <- @transaction_receipt.execution_resources do %>
             <%= if String.ends_with?(builtin_name, "_applications") and resources != "0x0" do %>
@@ -551,7 +551,7 @@ defmodule StarknetExplorerWeb.TransactionLive do
                 <span class={"#{Utils.builtin_color(temp_name)} py-1 px-2 rounded-lg"}>
                   <%= Utils.builtin_name(temp_name) %>
                 </span>
-                <%= Utils.hex_to_integer(resources) %>
+                <%= resources %>
               </div>
             <% end %>
           <% end %>

--- a/lib/starknet_explorer_web/live/transaction_live.ex
+++ b/lib/starknet_explorer_web/live/transaction_live.ex
@@ -392,7 +392,7 @@ defmodule StarknetExplorerWeb.TransactionLive do
       <div class="block-label">Actual Fee</div>
       <div class="col-span-3">
         <span class="info-label cash-label">
-          <%= Utils.hex_wei_to_eth(@transaction_receipt.actual_fee) %> ETH
+          <%= Utils.hex_wei_to_eth(@transaction_receipt.actual_fee["amount"]) %> ETH
         </span>
       </div>
     </div>

--- a/priv/repo/migrations/20230707152800_transaction_receipts.exs
+++ b/priv/repo/migrations/20230707152800_transaction_receipts.exs
@@ -8,7 +8,7 @@ defmodule StarknetExplorer.Repo.Migrations.TransactionReceipts do
 
       add :transaction_hash, :string, primary_key: true
       add :type, :string
-      add :actual_fee, :string
+      add :actual_fee, :map
       add :finality_status, :string
       add :execution_status, :string
       add :block_hash, :string


### PR DESCRIPTION
# Support Juno 0.9.2 responses
Make some changes to Support Juno 0.9.2 responses
* Change type TransactionReceipt.actual_fee to a map
* Changes in hex numbers representation
* Skip required fields check in invoke transactions