### PR TITLE
Remove required fields check from Deploy Account tx

### DIFF
--- a/lib/starknet_explorer/transaction.ex
+++ b/lib/starknet_explorer/transaction.ex
@@ -254,7 +254,7 @@ defmodule StarknetExplorer.Transaction do
 
   defp validate_according_to_tx_type(changeset, _tx = %{"type" => "DEPLOY_ACCOUNT"}) do
     changeset
-    |> validate_required(@deploy_account_tx_fields)
+    # |> validate_required(@deploy_account_tx_fields)
   end
 
   defp validate_according_to_tx_type(changeset, _tx = %{"type" => "DEPLOY"}) do


### PR DESCRIPTION
Remove required fields check from Deploy Account tx

[error] GenServer :testnet_state_sync terminating
** (Ecto.InvalidChangesetError) could not perform insert because changeset is invalid.


```
Changeset

    #Ecto.Changeset<
      action: :insert,
      changes: %{
        class_hash: "0x2fadbf77a721b94bdcc3032d86a8921661717fa55145bccf88160ee2a5efcd1",
        constructor_calldata: ["0x74c169c5cda8d5f205198c432381cfa71eff52f45fbff18d5a243a0be64b8f0",
         "0x0"],
        contract_address_salt: "0x74c169c5cda8d5f205198c432381cfa71eff52f45fbff18d5a243a0be64b8f0",
        hash: "0x3e62bb89efc8d1af707d2e1bec1fd72c0bc03f7f13a45afbd126c06761e442d",
        network: :testnet,
        nonce: "0x0",
        signature: ["0x5f515f16d4b9251e4d4420a11ffe9ef4cae759228b5a3898a0de6ce72a1d123",
         "0x4eddbe1993546a5dd9ff2eb8eca88a7e7f827eec837ede65ab2b2dff19037c"],
        type: "DEPLOY_ACCOUNT",
        version: "0x3"
      },
      errors: [max_fee: {"can't be blank", [validation: :required]}],
      data: #StarknetExplorer.Transaction<>,
      valid?: false
```


