### PR TITLE
Remove observer

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule StarknetExplorer.MixProject do
   def application do
     [
       mod: {StarknetExplorer.Application, []},
-      extra_applications: [:logger, :runtime_tools, :observer]
+      extra_applications: [:logger, :runtime_tools]
     ]
   end
 


### PR DESCRIPTION
Remove observer because it causes errors in some distros
```
iex -S mix phx.server
[notice] Application runtime_tools exited: :stopped
** (Mix) Could not start application observer: could not find application file: [observer.app](https://observer.app/)
```